### PR TITLE
update link to paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # K-BERT
 ![](https://img.shields.io/badge/license-MIT-000000.svg)
 
-Sorce code and datasets for ["K-BERT: Enabling Language Representation with Knowledge Graph"](https://aaai.org/Papers/AAAI/2020GB/AAAI-LiuW.5594.pdf), which is implemented based on the [UER](https://github.com/dbiir/UER-py) framework.
+Sorce code and datasets for ["K-BERT: Enabling Language Representation with Knowledge Graph"](https://ojs.aaai.org/index.php/AAAI/article/view/5681/5537), which is implemented based on the [UER](https://github.com/dbiir/UER-py) framework.
 
 
 ## Requirements


### PR DESCRIPTION
The link to the paper in the README (https://aaai.org/Papers/AAAI/2020GB/AAAI-LiuW.5594.pdf) doesn't seem to work anymore. This PR updates the README with a link (https://ojs.aaai.org/index.php/AAAI/article/view/5681/5537) that works.